### PR TITLE
Add API versioning prefix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,11 +10,12 @@ import { RequestIdMiddleware } from './shared/middleware/request-id/request-id.m
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.setGlobalPrefix('api/v1');
+
   app.useLogger(new AppLogger(app.get(Logger)));
   app.useGlobalPipes(new ValidationPipe());
   app.use(RequestIdMiddleware);
   app.enableCors();
-
 
   /** Swagger configuration*/
   const options = new DocumentBuilder()


### PR DESCRIPTION
Add API versioning prefix `api/v1`.
Currently adding it to the `main.ts` file.
Something that we could explore in the future is in this link:
https://github.com/nestjs/nest/issues/2654