### PR TITLE
feat: Refactor e2e tests

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -2,11 +2,19 @@ import * as request from 'supertest';
 import { Test } from '@nestjs/testing';
 import { AppModule } from './../src/app.module';
 import { INestApplication } from '@nestjs/common';
+import {
+  closeDBAfterTest,
+  createDBEntities,
+  resetDBBeforeTest,
+} from './test-utils';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
+    await resetDBBeforeTest();
+    await createDBEntities();
+
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
@@ -25,5 +33,6 @@ describe('AppController (e2e)', () => {
 
   afterAll(async () => {
     await app.close();
+    await closeDBAfterTest();
   });
 });

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,0 +1,47 @@
+import { createConnection, getConnection } from 'typeorm';
+
+const TEST_DB_CONNECTION_NAME = 'e2e_test_connection';
+export const TEST_DB_NAME = 'e2e_test_db';
+
+export const resetDBBeforeTest = async (): Promise<void> => {
+  // This overwrites the DB_NAME used in the SharedModule's TypeORM init.
+  // All the tests will run against the e2e db due to this overwrite.
+  process.env.DB_NAME = TEST_DB_NAME;
+
+  console.log(`Dropping ${TEST_DB_NAME} database and recreating it`);
+  const connection = await createConnection({
+    name: TEST_DB_CONNECTION_NAME,
+    type: 'mysql',
+    host: 'localhost',
+    port: 3306,
+    username: 'root',
+    password: 'example',
+  });
+
+  await connection.query(`drop database if exists ${TEST_DB_NAME}`);
+  await connection.query(`create database ${TEST_DB_NAME}`);
+
+  await connection.close();
+};
+
+export const createDBEntities = async (): Promise<void> => {
+  console.log(`Creating entities in ${TEST_DB_NAME} database`);
+  await createConnection({
+    name: TEST_DB_CONNECTION_NAME,
+    type: 'mysql',
+    host: 'localhost',
+    port: 3306,
+    username: 'root',
+    password: 'example',
+    database: TEST_DB_NAME,
+    entities: [__dirname + '/../src/**/*.entity{.ts,.js}'],
+    synchronize: true,
+  });
+};
+
+export const closeDBAfterTest = async (): Promise<void> => {
+  console.log(`Closing connection to ${TEST_DB_NAME} database`);
+  const connection = await getConnection(TEST_DB_CONNECTION_NAME);
+
+  await connection.close();
+};


### PR DESCRIPTION
The `e2e` tests will now run against it's own database `e2e_test_db` instead of using the one defined in `DB_NAME` env var.
The database server will still be the same as defined in the env vars.