### PR TITLE
Add isAccountDisabled field to user - Part 1/2

### DIFF
--- a/migrations/1608194453705-RefactorUserTable.ts
+++ b/migrations/1608194453705-RefactorUserTable.ts
@@ -1,0 +1,20 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class RefactorUserTable1608194453705 implements MigrationInterface {
+    name = 'RefactorUserTable1608194453705'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("ALTER TABLE `users` ADD `isAccountDisabled` tinyint NOT NULL");
+        await queryRunner.query("ALTER TABLE `users` ADD `email` varchar(200) NOT NULL");
+        await queryRunner.query("ALTER TABLE `users` ADD UNIQUE INDEX `IDX_97672ac88f789774dd47f7c8be` (`email`)");
+        await queryRunner.query("CREATE UNIQUE INDEX `email` ON `users` (`email`)");
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("DROP INDEX `email` ON `users`");
+        await queryRunner.query("ALTER TABLE `users` DROP INDEX `IDX_97672ac88f789774dd47f7c8be`");
+        await queryRunner.query("ALTER TABLE `users` DROP COLUMN `email`");
+        await queryRunner.query("ALTER TABLE `users` DROP COLUMN `isAccountDisabled`");
+    }
+
+}

--- a/migrations/1608194504651-RefactorUserTable.ts
+++ b/migrations/1608194504651-RefactorUserTable.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class RefactorUserTable1608194504651 implements MigrationInterface {
+    name = 'RefactorUserTable1608194504651'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("DROP INDEX `IDX_97672ac88f789774dd47f7c8be` ON `users`");
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("CREATE UNIQUE INDEX `IDX_97672ac88f789774dd47f7c8be` ON `users` (`email`)");
+    }
+
+}

--- a/src/auth/controllers/auth.controller.spec.ts
+++ b/src/auth/controllers/auth.controller.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { validateOrReject } from 'class-validator';
 
 import { AuthController } from './auth.controller';
 import { AuthService } from '../services/auth.service';
@@ -8,7 +7,6 @@ import { LoginInput } from '../dtos/auth-login-input.dto';
 import { RefreshTokenInput } from '../dtos/auth-refresh-token-input.dto';
 import {
   AuthTokenOutput,
-  UserAccessTokenClaims,
   UserRefreshTokenClaims,
 } from '../dtos/auth-token-output.dto';
 
@@ -41,7 +39,6 @@ describe('AuthController', () => {
       registerInputDto.name = 'John Doe';
       registerInputDto.username = 'john@example.com';
       registerInputDto.password = '123123';
-      await validateOrReject(registerInputDto);
 
       jest
         .spyOn(mockedAuthService, 'register')
@@ -59,7 +56,6 @@ describe('AuthController', () => {
       const loginInputDto = new LoginInput();
       loginInputDto.username = 'john@example.com';
       loginInputDto.password = '123123';
-      await validateOrReject(loginInputDto);
 
       const reqObject: any = {};
 
@@ -99,7 +95,6 @@ describe('AuthController', () => {
     });
 
     it('should generate refresh token', async () => {
-      await validateOrReject(refreshTokenInputDto);
       const response = await authController.refreshToken(
         request,
         refreshTokenInputDto,

--- a/src/auth/dtos/auth-register-input.dto.ts
+++ b/src/auth/dtos/auth-register-input.dto.ts
@@ -7,6 +7,8 @@ import {
   IsEnum,
   IsOptional,
   ArrayUnique,
+  IsEmail,
+  IsBoolean,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ROLE } from '../constants/role.constant';
@@ -35,4 +37,14 @@ export class RegisterInput {
   @ArrayUnique()
   @IsEnum(ROLE, { each: true })
   roles: ROLE[] = [ROLE.USER];
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsEmail()
+  @MaxLength(100)
+  email: string;
+
+  @ApiProperty()
+  @IsBoolean()
+  isAccountDisabled: boolean;
 }

--- a/src/auth/dtos/auth-register-output.dto.ts
+++ b/src/auth/dtos/auth-register-output.dto.ts
@@ -19,4 +19,12 @@ export class RegisterOutput {
   @Expose()
   @ApiProperty({ example: [ROLE.USER] })
   roles: ROLE[];
+
+  @Expose()
+  @ApiProperty()
+  email: string;
+
+  @Expose()
+  @ApiProperty()
+  isAccountDisabled: boolean;
 }

--- a/src/auth/services/auth.service.spec.ts
+++ b/src/auth/services/auth.service.spec.ts
@@ -19,6 +19,8 @@ describe('AuthService', () => {
     name: 'Jhon doe',
     password: 'any password',
     roles: [ROLE.USER],
+    isAccountDisabled: false,
+    email: 'randomUser@random.com',
   };
 
   const user = {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,8 @@ async function bootstrap() {
     username: 'default-admin',
     password: defaultAdminUserPassword,
     roles: [ROLE.ADMIN],
+    isAccountDisabled: false,
+    email: 'default-admin@example.com',
   };
 
   // Create the default admin user if it doesn't already exist.

--- a/src/user/controllers/user.controller.spec.ts
+++ b/src/user/controllers/user.controller.spec.ts
@@ -47,6 +47,8 @@ describe('UserController', () => {
     username: 'default-user',
     name: 'default-name',
     roles: [ROLE.USER],
+    isAccountDisabled: false,
+    email: 'e2etester@random.com',
   };
 
   describe('Get user by id', () => {

--- a/src/user/dtos/user-create-input.dto.ts
+++ b/src/user/dtos/user-create-input.dto.ts
@@ -1,27 +1,52 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   ArrayNotEmpty,
+  IsAlphanumeric,
   IsArray,
+  IsBoolean,
+  IsEmail,
   IsEnum,
   IsNotEmpty,
+  IsOptional,
   IsString,
+  Length,
+  MaxLength,
 } from 'class-validator';
 
 import { ROLE } from '../../auth/constants/role.constant';
 
 export class CreateUserInput {
+  @ApiPropertyOptional()
+  @IsOptional()
   @IsNotEmpty()
   @IsString()
   name: string;
 
-  @IsString()
+  @ApiProperty()
+  @IsNotEmpty()
+  @Length(6, 100)
+  @IsAlphanumeric()
   username: string;
 
+  @ApiProperty()
   @IsNotEmpty()
   @IsString()
+  @Length(6, 100)
   password: string;
 
+  @ApiProperty()
   @IsArray()
   @ArrayNotEmpty()
   @IsEnum(ROLE, { each: true })
   roles: ROLE[];
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsEmail()
+  @MaxLength(100)
+  email: string;
+
+  @ApiProperty()
+  @IsBoolean()
+  isAccountDisabled: boolean;
 }

--- a/src/user/dtos/user-output.dto.ts
+++ b/src/user/dtos/user-output.dto.ts
@@ -19,4 +19,12 @@ export class UserOutput {
   @Expose()
   @ApiProperty({ example: [ROLE.USER] })
   roles: ROLE[];
+
+  @Expose()
+  @ApiProperty()
+  email: string;
+
+  @Expose()
+  @ApiProperty()
+  isAccountDisabled: boolean;
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -17,4 +17,11 @@ export class User {
 
   @Column('simple-array')
   roles: string[];
+
+  @Column()
+  isAccountDisabled: boolean;
+
+  @Unique('email', ['email'])
+  @Column({ length: 200 })
+  email: string;
 }

--- a/src/user/repositories/user.repository.spec.ts
+++ b/src/user/repositories/user.repository.spec.ts
@@ -29,6 +29,8 @@ describe('UserRepository', () => {
         username: 'default-user',
         password: 'random-password',
         roles: [ROLE.USER],
+        isAccountDisabled: false,
+        email: 'default-user@random.com',
       };
 
       jest.spyOn(repository, 'findOne').mockResolvedValue(expectedOutput);
@@ -43,6 +45,8 @@ describe('UserRepository', () => {
         username: 'default-user',
         password: 'random-password',
         roles: [ROLE.USER],
+        isAccountDisabled: false,
+        email: 'default-user@random.com',
       };
 
       jest.spyOn(repository, 'findOne').mockResolvedValue(expectedOutput);

--- a/src/user/services/user.service.spec.ts
+++ b/src/user/services/user.service.spec.ts
@@ -60,6 +60,8 @@ describe('UserService', () => {
         username: user.username,
         password: 'plain-password',
         roles: [ROLE.USER],
+        isAccountDisabled: false,
+        email: 'randomUser@random.com',
       };
 
       await service.createUser(userInput);
@@ -72,6 +74,8 @@ describe('UserService', () => {
         username: user.username,
         password: 'plain-password',
         roles: [ROLE.USER],
+        isAccountDisabled: false,
+        email: 'randomUser@random.com',
       };
 
       await service.createUser(userInput);
@@ -81,6 +85,8 @@ describe('UserService', () => {
         username: user.username,
         password: 'hashed-password',
         roles: [ROLE.USER],
+        isAccountDisabled: false,
+        email: 'randomUser@random.com',
       });
     });
 
@@ -95,6 +101,8 @@ describe('UserService', () => {
         username: user.username,
         password: 'plain-password',
         roles: [ROLE.USER],
+        isAccountDisabled: false,
+        email: 'randomUser@random.com',
       };
 
       const result = await service.createUser(userInput);
@@ -104,6 +112,8 @@ describe('UserService', () => {
         name: userInput.name,
         username: userInput.username,
         roles: [ROLE.USER],
+        isAccountDisabled: false,
+        email: 'randomUser@random.com',
       });
       expect(result).not.toHaveProperty('password');
     });
@@ -227,12 +237,15 @@ describe('UserService', () => {
         password: 'updated-password',
       };
 
-      const foundUser = new User();
-      foundUser.id = userId;
-      foundUser.name = 'Default User';
-      foundUser.username = 'default-user';
-      foundUser.password = 'random-password';
-      foundUser.roles = [ROLE.USER];
+      const foundUser: User = {
+        id: userId,
+        name: 'Default User',
+        username: 'default-user',
+        password: 'random-password',
+        roles: [ROLE.USER],
+        isAccountDisabled: false,
+        email: 'randomUser@random.com',
+      };
       mockedRepository.getById.mockResolvedValue(foundUser);
 
       const expected: User = {
@@ -241,6 +254,8 @@ describe('UserService', () => {
         username: 'default-user',
         password: input.password,
         roles: [ROLE.USER],
+        isAccountDisabled: false,
+        email: 'randomUser@random.com',
       };
 
       jest

--- a/test/auth/auth.e2e-spec.ts
+++ b/test/auth/auth.e2e-spec.ts
@@ -34,15 +34,19 @@ describe('AuthController (e2e)', () => {
   describe('register a new user', () => {
     const registerInput: RegisterInput = {
       name: 'e2etester',
-      username: 'e2etester@random.com',
+      username: 'e2etester',
       password: '12345678',
       roles: [ROLE.USER],
+      isAccountDisabled: false,
+      email: 'e2etester@random.com',
     };
     const registerOutput: RegisterOutput = {
       id: 1,
       name: 'e2etester',
-      username: 'e2etester@random.com',
+      username: 'e2etester',
       roles: [ROLE.USER],
+      isAccountDisabled: false,
+      email: 'e2etester@random.com',
     };
 
     it('successfully register a new user', () => {
@@ -76,7 +80,7 @@ describe('AuthController (e2e)', () => {
 
   describe('login the registered user', () => {
     const loginInput: LoginInput = {
-      username: 'e2etester@random.com',
+      username: 'e2etester',
       password: '12345678',
     };
 
@@ -102,7 +106,7 @@ describe('AuthController (e2e)', () => {
 
   describe('refreshing jwt token', () => {
     const loginInput: LoginInput = {
-      username: 'e2etester@random.com',
+      username: 'e2etester',
       password: '12345678',
     };
 

--- a/test/user/user.e2e-spec.ts
+++ b/test/user/user.e2e-spec.ts
@@ -31,14 +31,16 @@ describe('UserController (e2e)', () => {
 
     // Create a User
     const registerInput: RegisterInput = {
-      name: 'e2etester',
-      username: 'e2etester@random.com',
+      name: 'e2e tester',
+      username: 'e2etester',
       password: '12345678',
       roles: [ROLE.USER],
+      isAccountDisabled: false,
+      email: 'e2etester@random.com',
     };
 
     const loginInput: LoginInput = {
-      username: 'e2etester@random.com',
+      username: 'e2etester',
       password: '12345678',
     };
 
@@ -79,9 +81,11 @@ describe('UserController (e2e)', () => {
 
   const userOutput: UserOutput = {
     id: 1,
-    name: 'e2etester',
-    username: 'e2etester@random.com',
+    name: 'e2e tester',
+    username: 'e2etester',
     roles: [ROLE.USER],
+    isAccountDisabled: false,
+    email: 'e2etester@random.com',
   };
 
   describe('get all users', () => {


### PR DESCRIPTION
Add isAccountDisabled field to user - Part 1/2

This field will allow us to prevent disabled `users` from logging in.

In next follow-up PR:
- Will add logic to prevent `login` for users who have the flag `isAccountDisabled` set to true.
