### PR TITLE
feat: admin user create for e2e tests

### DIFF
--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -4,7 +4,6 @@ import { JwtService } from '@nestjs/jwt';
 import { plainToClass } from 'class-transformer';
 
 import { UserService } from '../../user/services/user.service';
-import { ROLE } from '../constants/role.constant';
 import { RegisterInput } from '../dtos/auth-register-input.dto';
 import { RegisterOutput } from '../dtos/auth-register-output.dto';
 import {
@@ -39,9 +38,6 @@ export class AuthService {
   }
 
   async register(input: RegisterInput): Promise<RegisterOutput> {
-    // TODO : Setting default role as USER here. Will add option to change this later via ADMIN users.
-    input.roles = [ROLE.USER];
-
     const registeredUser = await this.userService.createUser(input);
     return plainToClass(RegisterOutput, registeredUser, {
       excludeExtraneousValues: true,

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -4,6 +4,7 @@ import { JwtService } from '@nestjs/jwt';
 import { plainToClass } from 'class-transformer';
 
 import { UserService } from '../../user/services/user.service';
+import { ROLE } from '../constants/role.constant';
 import { RegisterInput } from '../dtos/auth-register-input.dto';
 import { RegisterOutput } from '../dtos/auth-register-output.dto';
 import {
@@ -38,6 +39,9 @@ export class AuthService {
   }
 
   async register(input: RegisterInput): Promise<RegisterOutput> {
+    // TODO : Setting default role as USER here. Will add option to change this later via ADMIN users.
+    input.roles = [ROLE.USER];
+
     const registeredUser = await this.userService.createUser(input);
     return plainToClass(RegisterOutput, registeredUser, {
       excludeExtraneousValues: true,

--- a/test/auth/auth.e2e-spec.ts
+++ b/test/auth/auth.e2e-spec.ts
@@ -5,6 +5,7 @@ import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
 
 import {
   closeDBAfterTest,
+  createAdminUser,
   createDBEntities,
   resetDBBeforeTest,
 } from './../test-utils';
@@ -17,6 +18,7 @@ import { ROLE } from '../../src/auth/constants/role.constant';
 
 describe('AuthController (e2e)', () => {
   let app: INestApplication;
+  let authTokenForAdmin: AuthTokenOutput;
 
   beforeAll(async () => {
     await resetDBBeforeTest();
@@ -29,6 +31,15 @@ describe('AuthController (e2e)', () => {
     app = moduleRef.createNestApplication();
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
+
+    authTokenForAdmin = await createAdminUser(app);
+  });
+
+  describe('Admin User Auth Tokens', () => {
+    it('presence of Auth Tokens for admin ', async () => {
+      expect(authTokenForAdmin).toHaveProperty('accessToken');
+      expect(authTokenForAdmin).toHaveProperty('refreshToken');
+    });
   });
 
   describe('register a new user', () => {
@@ -41,7 +52,7 @@ describe('AuthController (e2e)', () => {
       email: 'e2etester@random.com',
     };
     const registerOutput: RegisterOutput = {
-      id: 1,
+      id: 2,
       name: 'e2etester',
       username: 'e2etester',
       roles: [ROLE.USER],

--- a/test/auth/auth.e2e-spec.ts
+++ b/test/auth/auth.e2e-spec.ts
@@ -32,7 +32,7 @@ describe('AuthController (e2e)', () => {
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
 
-    authTokenForAdmin = await createAdminUser(app);
+    ({ authTokenForAdmin } = await createAdminUser(app));
   });
 
   describe('Admin User Auth Tokens', () => {

--- a/test/auth/auth.e2e-spec.ts
+++ b/test/auth/auth.e2e-spec.ts
@@ -5,7 +5,7 @@ import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
 
 import {
   closeDBAfterTest,
-  createAdminUser,
+  seedAdminUser,
   createDBEntities,
   resetDBBeforeTest,
 } from './../test-utils';
@@ -32,7 +32,7 @@ describe('AuthController (e2e)', () => {
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
 
-    ({ authTokenForAdmin } = await createAdminUser(app));
+    ({ authTokenForAdmin } = await seedAdminUser(app));
   });
 
   describe('Admin User Auth Tokens', () => {

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -8,6 +8,7 @@ import { CreateUserInput } from '../src/user/dtos/user-create-input.dto';
 import { ROLE } from '../src/auth/constants/role.constant';
 import { LoginInput } from 'src/auth/dtos/auth-login-input.dto';
 import { AuthTokenOutput } from 'src/auth/dtos/auth-token-output.dto';
+import { UserOutput } from 'src/user/dtos/user-output.dto';
 
 const TEST_DB_CONNECTION_NAME = 'e2e_test_connection';
 export const TEST_DB_NAME = 'e2e_test_db';
@@ -50,7 +51,7 @@ export const createDBEntities = async (): Promise<void> => {
 
 export const createAdminUser = async (
   app: INestApplication,
-): Promise<AuthTokenOutput> => {
+): Promise<{ adminUser: UserOutput; authTokenForAdmin: AuthTokenOutput }> => {
   const defaultAdmin: CreateUserInput = {
     name: 'Default Admin User',
     username: 'default-admin',
@@ -75,9 +76,18 @@ export const createAdminUser = async (
     .send(loginInput)
     .expect(HttpStatus.OK);
 
-  const authToken: AuthTokenOutput = loginResponse.body.data;
+  const authTokenForAdmin: AuthTokenOutput = loginResponse.body.data;
 
-  return authToken;
+  const adminUser: UserOutput = {
+    id: 1,
+    name: 'Default Admin User',
+    username: 'default-admin',
+    roles: [ROLE.ADMIN],
+    isAccountDisabled: false,
+    email: 'default-admin@example.com',
+  };
+
+  return { adminUser, authTokenForAdmin };
 };
 
 export const closeDBAfterTest = async (): Promise<void> => {

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -4,11 +4,11 @@ import * as request from 'supertest';
 
 import { UserService } from '../src/user/services/user.service';
 
-import { CreateUserInput } from '../src/user/dtos/user-create-input.dto';
 import { ROLE } from '../src/auth/constants/role.constant';
-import { LoginInput } from 'src/auth/dtos/auth-login-input.dto';
-import { AuthTokenOutput } from 'src/auth/dtos/auth-token-output.dto';
-import { UserOutput } from 'src/user/dtos/user-output.dto';
+import { CreateUserInput } from '../src/user/dtos/user-create-input.dto';
+import { LoginInput } from '../src/auth/dtos/auth-login-input.dto';
+import { AuthTokenOutput } from '../src/auth/dtos/auth-token-output.dto';
+import { UserOutput } from '../src/user/dtos/user-output.dto';
 
 const TEST_DB_CONNECTION_NAME = 'e2e_test_connection';
 export const TEST_DB_NAME = 'e2e_test_db';
@@ -63,7 +63,7 @@ export const createAdminUser = async (
 
   // Creating Admin User
   const userService = app.get(UserService);
-  await userService.createUser(defaultAdmin);
+  const adminUser = { ...(await userService.createUser(defaultAdmin)) };
 
   const loginInput: LoginInput = {
     username: 'default-admin',
@@ -77,15 +77,6 @@ export const createAdminUser = async (
     .expect(HttpStatus.OK);
 
   const authTokenForAdmin: AuthTokenOutput = loginResponse.body.data;
-
-  const adminUser: UserOutput = {
-    id: 1,
-    name: 'Default Admin User',
-    username: 'default-admin',
-    roles: [ROLE.ADMIN],
-    isAccountDisabled: false,
-    email: 'default-admin@example.com',
-  };
 
   return { adminUser, authTokenForAdmin };
 };

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -49,7 +49,7 @@ export const createDBEntities = async (): Promise<void> => {
   });
 };
 
-export const createAdminUser = async (
+export const seedAdminUser = async (
   app: INestApplication,
 ): Promise<{ adminUser: UserOutput; authTokenForAdmin: AuthTokenOutput }> => {
   const defaultAdmin: CreateUserInput = {
@@ -63,7 +63,7 @@ export const createAdminUser = async (
 
   // Creating Admin User
   const userService = app.get(UserService);
-  const adminUser = { ...(await userService.createUser(defaultAdmin)) };
+  const userOutput = await userService.createUser(defaultAdmin);
 
   const loginInput: LoginInput = {
     username: 'default-admin',
@@ -77,6 +77,8 @@ export const createAdminUser = async (
     .expect(HttpStatus.OK);
 
   const authTokenForAdmin: AuthTokenOutput = loginResponse.body.data;
+
+  const adminUser: UserOutput = { ...userOutput };
 
   return { adminUser, authTokenForAdmin };
 };

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -66,8 +66,8 @@ export const seedAdminUser = async (
   const userOutput = await userService.createUser(defaultAdmin);
 
   const loginInput: LoginInput = {
-    username: 'default-admin',
-    password: 'default-admin-password',
+    username: defaultAdmin.username,
+    password: defaultAdmin.password,
   };
 
   // Logging in Admin User to get AuthToken

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -2,6 +2,8 @@ import { createConnection, getConnection } from 'typeorm';
 import { HttpStatus, INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 
+import { UserService } from '../src/user/services/user.service';
+
 import { CreateUserInput } from '../src/user/dtos/user-create-input.dto';
 import { ROLE } from '../src/auth/constants/role.constant';
 import { LoginInput } from 'src/auth/dtos/auth-login-input.dto';
@@ -59,10 +61,8 @@ export const createAdminUser = async (
   };
 
   // Creating Admin User
-  await request(app.getHttpServer())
-    .post('/auth/register')
-    .send(defaultAdmin)
-    .expect(HttpStatus.CREATED);
+  const userService = app.get(UserService);
+  await userService.createUser(defaultAdmin);
 
   const loginInput: LoginInput = {
     username: 'default-admin',

--- a/test/user/user.e2e-spec.ts
+++ b/test/user/user.e2e-spec.ts
@@ -11,11 +11,11 @@ import {
   createAdminUser,
 } from '../test-utils';
 import { UserOutput } from '../../src/user/dtos/user-output.dto';
-import { ROLE } from '../../src/auth/constants/role.constant';
 import { AuthTokenOutput } from '../../src/auth/dtos/auth-token-output.dto';
 
 describe('UserController (e2e)', () => {
   let app: INestApplication;
+  let adminUser: UserOutput;
   let authTokenForAdmin: AuthTokenOutput;
 
   beforeAll(async () => {
@@ -30,7 +30,7 @@ describe('UserController (e2e)', () => {
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
 
-    authTokenForAdmin = await createAdminUser(app);
+    ({ adminUser, authTokenForAdmin } = await createAdminUser(app));
   });
 
   describe('Get user me', () => {
@@ -55,19 +55,10 @@ describe('UserController (e2e)', () => {
     });
   });
 
-  const userOutput: UserOutput = {
-    id: 1,
-    name: 'Default Admin User',
-    username: 'default-admin',
-    roles: [ROLE.ADMIN],
-    email: 'default-admin@example.com',
-    isAccountDisabled: false,
-  };
-
   describe('get all users', () => {
-    const expectedOutput = [userOutput];
-
     it('returns all users', async () => {
+      const expectedOutput = [adminUser];
+
       return request(app.getHttpServer())
         .get('/users')
         .set('Authorization', 'Bearer ' + authTokenForAdmin.accessToken)
@@ -77,9 +68,9 @@ describe('UserController (e2e)', () => {
   });
 
   describe('get a user by Id', () => {
-    const expectedOutput = userOutput;
-
     it('should get a user by Id', async () => {
+      const expectedOutput = adminUser;
+
       return request(app.getHttpServer())
         .get('/users/1')
         .expect(HttpStatus.OK)
@@ -98,17 +89,13 @@ describe('UserController (e2e)', () => {
     password: '12345678aA12',
   };
 
-  const expectedOutput: UserOutput = {
-    id: 1,
-    name: 'New e2etestername',
-    username: 'default-admin',
-    roles: [ROLE.ADMIN],
-    email: 'default-admin@example.com',
-    isAccountDisabled: false,
-  };
-
   describe('update a user', () => {
     it('successfully updates a user', async () => {
+      const expectedOutput: UserOutput = {
+        ...adminUser,
+        ...{ name: 'New e2etestername' },
+      };
+
       return request(app.getHttpServer())
         .patch('/users/1')
         .send(updateUserInput)

--- a/test/user/user.e2e-spec.ts
+++ b/test/user/user.e2e-spec.ts
@@ -8,7 +8,7 @@ import {
   resetDBBeforeTest,
   createDBEntities,
   closeDBAfterTest,
-  createAdminUser,
+  seedAdminUser,
 } from '../test-utils';
 import { UserOutput } from '../../src/user/dtos/user-output.dto';
 import { AuthTokenOutput } from '../../src/auth/dtos/auth-token-output.dto';
@@ -30,7 +30,7 @@ describe('UserController (e2e)', () => {
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
 
-    ({ adminUser, authTokenForAdmin } = await createAdminUser(app));
+    ({ adminUser, authTokenForAdmin } = await seedAdminUser(app));
   });
 
   describe('Get user me', () => {


### PR DESCRIPTION
 Create an admin user and share it’s access token for testing admin routes. 