### PR TITLE
Replace Pino with Winston Logger - Part 2/3

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ $ npm run migration:revert
 
 ## Architecture
 
-- [Project Structure - ](./docs/project-structure.md)
+- [Project Structure](./docs/project-structure.md)
 
 ## External Links
 

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AppLogger } from './shared/logger/logger.service';
+import { RequestContext } from './shared/request-context/request-context.dto';
 
 describe('AppController', () => {
   let moduleRef: TestingModule;
@@ -20,7 +21,8 @@ describe('AppController', () => {
   describe('getHello', () => {
     it('should return "Hello World!"', () => {
       const appController = moduleRef.get<AppController>(AppController);
-      expect(appController.getHello()).toBe('Hello World!');
+      const ctx = new RequestContext();
+      expect(appController.getHello(ctx)).toBe('Hello World!');
     });
   });
 });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { RequestContext } from './shared/request-context/request-context.dto';
 import { AppLogger } from './shared/logger/logger.service';
+import { ReqContext } from './shared/request-context/req-context.decorator';
 
 @Controller()
 export class AppController {
@@ -12,7 +14,9 @@ export class AppController {
   }
 
   @Get()
-  getHello(): string {
+  getHello(@ReqContext() ctx: RequestContext): string {
+    console.log('ctx', ctx);
+
     this.logger.log('Hello world from App controller');
 
     return this.appService.getHello();

--- a/src/article/services/article.service.spec.ts
+++ b/src/article/services/article.service.spec.ts
@@ -110,6 +110,15 @@ describe('ArticleService', () => {
         post: 'New Post',
       };
 
+      const author = new User();
+      author.id = 1;
+      mockedRepository.getById.mockResolvedValue({
+        id: 1,
+        title: 'Old title',
+        post: 'Old post',
+        author,
+      });
+
       service.updateArticle(userClaims, articleId, input);
       expect(mockedRepository.getById).toHaveBeenCalledWith(articleId);
     });

--- a/src/shared/request-context/req-context.decorator.ts
+++ b/src/shared/request-context/req-context.decorator.ts
@@ -1,0 +1,17 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { REQUEST_ID_TOKEN_HEADER } from '../constants';
+import { RequestContext } from './request-context.dto';
+
+export const ReqContext = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): RequestContext => {
+    const request = ctx.switchToHttp().getRequest();
+
+    const requestContext = new RequestContext();
+    requestContext.requestID = request.header(REQUEST_ID_TOKEN_HEADER);
+
+    // If request.user does not exist, we explicitly set it to null.
+    requestContext.user = request.user ? request.user : null;
+
+    return requestContext;
+  },
+);

--- a/src/shared/request-context/request-context.dto.ts
+++ b/src/shared/request-context/request-context.dto.ts
@@ -1,0 +1,7 @@
+import { UserAccessTokenClaims } from '../../auth/dtos/auth-token-output.dto';
+
+export class RequestContext {
+  public requestID: string;
+  // TODO : Discuss with team if this import is acceptable or if we should move UserAccessTokenClaims to shared.
+  public user: UserAccessTokenClaims;
+}


### PR DESCRIPTION
Replace Pino with Winston Logger - Part 2/3
- Create `RequestContext` Decorator. It gives access to the request specific context.