### PR TITLE
Replace Pino with Winston Logger - Part 3/4 

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -6,7 +6,7 @@ import { RequestContext } from './shared/request-context/request-context.dto';
 
 describe('AppController', () => {
   let moduleRef: TestingModule;
-  const mockedLogger = { setContext: jest.fn(), log: jest.fn() };
+  const mockedLogger = { setContext: jest.fn(), logWithContext: jest.fn() };
 
   beforeEach(async () => {
     moduleRef = await Test.createTestingModule({

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -15,10 +15,8 @@ export class AppController {
 
   @Get()
   getHello(@ReqContext() ctx: RequestContext): string {
-    console.log('ctx', ctx);
+    this.logger.logWithContext(ctx, 'Hello world from App controller');
 
-    this.logger.log('Hello world from App controller');
-
-    return this.appService.getHello();
+    return this.appService.getHello(ctx);
   }
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { AppLogger } from './shared/logger/logger.service';
+import { RequestContext } from './shared/request-context/request-context.dto';
 
 @Injectable()
 export class AppService {
@@ -7,8 +8,8 @@ export class AppService {
     this.logger.setContext(AppService.name);
   }
 
-  getHello(): string {
-    this.logger.log('Hello world from App service');
+  getHello(ctx: RequestContext): string {
+    this.logger.logWithContext(ctx, 'Hello world from App service');
 
     return 'Hello World!';
   }

--- a/src/shared/logger/logger.service.ts
+++ b/src/shared/logger/logger.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, LoggerService, Scope } from '@nestjs/common';
 import { createLogger, Logger, transports } from 'winston';
+import { RequestContext } from '../request-context/request-context.dto';
 
 @Injectable({ scope: Scope.TRANSIENT })
 export class AppLogger implements LoggerService {
@@ -49,6 +50,17 @@ export class AppLogger implements LoggerService {
   verbose(message: any, context?: string): Logger {
     return this.logger.verbose(message, {
       context: context || this.context,
+    });
+  }
+
+  // TODO : This is a temporary function, it will be renamed to `log` once we update it across
+  // all controllers, services, etc.
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  logWithContext(ctx: RequestContext, message: any): Logger {
+    return this.logger.info({
+      message,
+      ctx,
+      contextName: this.context,
     });
   }
 }

--- a/src/shared/request-context/req-context.decorator.ts
+++ b/src/shared/request-context/req-context.decorator.ts
@@ -2,6 +2,9 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { REQUEST_ID_TOKEN_HEADER } from '../constants';
 import { RequestContext } from './request-context.dto';
 
+// NOTE : Please keep in mind the order in which we import the decorators, guards, etc.
+// Since ReqContext decorator assumes the req.user to exist, it should always be
+// called after the JwtAuthGuard guard.
 export const ReqContext = createParamDecorator(
   (data: unknown, ctx: ExecutionContext): RequestContext => {
     const request = ctx.switchToHttp().getRequest();


### PR DESCRIPTION
Add `logWithContext` function. This will be renamed to `log` once we replace it across all controllers, services, etc.
Will replace this in all modules in `PR 4/4`.