### PR TITLE
Proposal: Dockerizing npm for local and CI environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ If you would like to use a more feature rich starter kit, with more awesome feat
 
 ## Installation
 
+Note: when using docker, all the `npm` commands can also be performed using `./scripts/npm` (for example `./scripts/npm install`).
+This script allows you to run the same commands inside the same environment and versions than the service, without relying on what is installed on the host.
+
 ```bash
 $ npm install
 ```

--- a/scripts/npm
+++ b/scripts/npm
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This scripts allows to use npm with the same version and
+# environment than the running service, using docker-compose.
+# This also allows to use it when not installed on the host.
+
+APP_SERVICE_IN_DOCKER_COMPOSE="app"
+
+getAppImage() {
+    docker-compose images --quiet $APP_SERVICE_IN_DOCKER_COMPOSE
+}
+
+if [ -z "$(getAppImage)" ]; then
+    # To be able to get the image created by docker-compose,
+    # we need the container to exist. This command makes sure
+    # that the container exists, and if necessary will build
+    # the image only the first time. We don't want to waste
+    # time building a new image everytime we call npm,
+    # so there is no need to use --build
+
+    echo -e "\e[32m\e[1mApp container not available. Building it\e[0m"
+    docker-compose create $APP_SERVICE_IN_DOCKER_COMPOSE
+fi
+
+echo -e "\e[32m\e[1mRunning npm inside docker\e[0m"
+docker run -v ${PWD}:/usr/src/app -it --rm "$(getAppImage)" npm $@


### PR DESCRIPTION
I noticed that the current way is relying on whatever version of NodeJS and npm are installed on the host.
This is more difficult when working with multiple (and legacy) projects with multiple versions or running in a CI environment.

This script makes is easy to use a dockerized npm by seamlessly running `./scripts/npm whatever`.