### PR TITLE
feat: refactor ACL service

### DIFF
--- a/src/article/services/article-acl.service.ts
+++ b/src/article/services/article-acl.service.ts
@@ -7,7 +7,7 @@ import { Actor } from '../../shared/acl/actor.constant';
 import { Article } from '../entities/article.entity';
 
 @Injectable()
-export class ArticleAclService extends BaseAclService {
+export class ArticleAclService extends BaseAclService<Article> {
   constructor() {
     super();
     this.canDo(ROLE.ADMIN, [Action.Manage]);

--- a/src/shared/acl/acl-rule.constant.ts
+++ b/src/shared/acl/acl-rule.constant.ts
@@ -1,17 +1,16 @@
 import { ROLE } from './../../auth/constants/role.constant';
 import { Action } from './action.constant';
 import { Actor } from './actor.constant';
-import { Resource } from './resource.constant';
 
 /**
  * Custom rule callback definition
  */
-export type RuleCallback = (resource: Resource, actor: Actor) => boolean;
+export type RuleCallback<T> = (resource: T, actor: Actor) => boolean;
 
 /**
  * ACL rule format
  */
-export type AclRule = {
+export type AclRule<T> = {
   //if rule for particular role or for all role
   role: ROLE;
 
@@ -19,5 +18,5 @@ export type AclRule = {
   actions: Action[];
 
   //specific rule there or otherwise true
-  ruleCallback?: RuleCallback;
+  ruleCallback?: RuleCallback<T>;
 };

--- a/src/shared/acl/acl-rule.constant.ts
+++ b/src/shared/acl/acl-rule.constant.ts
@@ -5,12 +5,15 @@ import { Actor } from './actor.constant';
 /**
  * Custom rule callback definition
  */
-export type RuleCallback<T> = (resource: T, actor: Actor) => boolean;
+export type RuleCallback<Resource> = (
+  resource: Resource,
+  actor: Actor,
+) => boolean;
 
 /**
  * ACL rule format
  */
-export type AclRule<T> = {
+export type AclRule<Resource> = {
   //if rule for particular role or for all role
   role: ROLE;
 
@@ -18,5 +21,5 @@ export type AclRule<T> = {
   actions: Action[];
 
   //specific rule there or otherwise true
-  ruleCallback?: RuleCallback<T>;
+  ruleCallback?: RuleCallback<Resource>;
 };

--- a/src/shared/acl/acl.service.spec.ts
+++ b/src/shared/acl/acl.service.spec.ts
@@ -5,8 +5,16 @@ import { BaseAclService } from './acl.service';
 import { RuleCallback } from './acl-rule.constant';
 import { Action } from './action.constant';
 
-class MockAclService extends BaseAclService {
-  public canDo(role: ROLE, actions: Action[], ruleCallback?: RuleCallback) {
+class MockResource {
+  id: number;
+}
+
+class MockAclService extends BaseAclService<MockResource> {
+  public canDo(
+    role: ROLE,
+    actions: Action[],
+    ruleCallback?: RuleCallback<MockResource>,
+  ) {
     super.canDo(role, actions, ruleCallback);
   }
 

--- a/src/shared/acl/acl.service.ts
+++ b/src/shared/acl/acl.service.ts
@@ -2,13 +2,12 @@ import { ROLE } from './../../auth/constants/role.constant';
 import { AclRule, RuleCallback } from './acl-rule.constant';
 import { Action } from './action.constant';
 import { Actor } from './actor.constant';
-import { Resource } from './resource.constant';
 
-export class BaseAclService {
+export class BaseAclService<T> {
   /**
    * ACL rules
    */
-  protected aclRules: AclRule[] = [];
+  protected aclRules: AclRule<T>[] = [];
 
   /**
    * Set ACL rule for a role
@@ -16,7 +15,7 @@ export class BaseAclService {
   protected canDo(
     role: ROLE,
     actions: Action[],
-    ruleCallback?: RuleCallback,
+    ruleCallback?: RuleCallback<T>,
   ): void {
     ruleCallback
       ? this.aclRules.push({ role, actions, ruleCallback })
@@ -28,7 +27,7 @@ export class BaseAclService {
    */
   public forActor = (actor: Actor): any => {
     return {
-      canDoAction: (action: Action, resource?: Resource) => {
+      canDoAction: (action: Action, resource?: T) => {
         let canDoAction = false;
 
         actor.roles.forEach((actorRole) => {

--- a/src/shared/acl/acl.service.ts
+++ b/src/shared/acl/acl.service.ts
@@ -3,11 +3,11 @@ import { AclRule, RuleCallback } from './acl-rule.constant';
 import { Action } from './action.constant';
 import { Actor } from './actor.constant';
 
-export class BaseAclService<T> {
+export class BaseAclService<Resource> {
   /**
    * ACL rules
    */
-  protected aclRules: AclRule<T>[] = [];
+  protected aclRules: AclRule<Resource>[] = [];
 
   /**
    * Set ACL rule for a role
@@ -15,7 +15,7 @@ export class BaseAclService<T> {
   protected canDo(
     role: ROLE,
     actions: Action[],
-    ruleCallback?: RuleCallback<T>,
+    ruleCallback?: RuleCallback<Resource>,
   ): void {
     ruleCallback
       ? this.aclRules.push({ role, actions, ruleCallback })
@@ -27,7 +27,7 @@ export class BaseAclService<T> {
    */
   public forActor = (actor: Actor): any => {
     return {
-      canDoAction: (action: Action, resource?: T) => {
+      canDoAction: (action: Action, resource?: Resource) => {
         let canDoAction = false;
 
         actor.roles.forEach((actorRole) => {

--- a/src/shared/acl/resource.constant.ts
+++ b/src/shared/acl/resource.constant.ts
@@ -1,6 +1,0 @@
-/**
- * ACL resource
- */
-export type Resource = {
-  id: number;
-};

--- a/src/user/services/user-acl.service.ts
+++ b/src/user/services/user-acl.service.ts
@@ -7,7 +7,7 @@ import { Action } from './../../shared/acl/action.constant';
 import { Actor } from './../../shared/acl/actor.constant';
 
 @Injectable()
-export class UserAclService extends BaseAclService {
+export class UserAclService extends BaseAclService<User> {
   constructor() {
     super();
     // Admin can do all action


### PR DESCRIPTION
feat: refactor ACL service

This refactor allows us to have more dynamic `ruleCallback` logic. It allows us to act on any property of the resource being passed instead of sticking to the original `Resource` type with just `id` from our ACL service. 

- Refactored BaseACLService to accept a generic type `<T>`. 
- Completely removed type `Resource` as it is not needed anywhere. If we wanted to have some logic in our BasACLService which does some action on the `resource` then we could have had `T extends Resource`, but ATM, we are simply passing the resource object to the `ruleCallback` function. 

We came up with this approach during pair-programming session between myself and @Seb-C 