### PR TITLE
fix: unique constraint error while registering user

### DIFF
--- a/src/auth/dtos/auth-register-input.dto.ts
+++ b/src/auth/dtos/auth-register-input.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import {
   IsEmail,
   IsNotEmpty,

--- a/src/auth/services/auth.service.spec.ts
+++ b/src/auth/services/auth.service.spec.ts
@@ -55,7 +55,7 @@ describe('AuthService', () => {
     createUser: jest.fn(),
     validateUsernamePassword: jest.fn(),
     findByUsername: jest.fn(),
-    findByEmail: jest.fn(),
+    findByUsernameOrEmail: jest.fn(),
   };
 
   const mockedJwtService = {
@@ -150,7 +150,7 @@ describe('AuthService', () => {
 
     it('should throw bad request exception for existing username', async () => {
       jest
-        .spyOn(mockedUserService, 'findByUsername')
+        .spyOn(mockedUserService, 'findByUsernameOrEmail')
         .mockImplementation(() => true);
 
       await expect(service.register(ctx, registerInput)).rejects.toThrowError(

--- a/src/auth/services/auth.service.spec.ts
+++ b/src/auth/services/auth.service.spec.ts
@@ -1,4 +1,4 @@
-import { UnauthorizedException } from '@nestjs/common';
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -54,6 +54,8 @@ describe('AuthService', () => {
     findById: jest.fn(),
     createUser: jest.fn(),
     validateUsernamePassword: jest.fn(),
+    findByUsername: jest.fn(),
+    findByEmail: jest.fn(),
   };
 
   const mockedJwtService = {
@@ -144,6 +146,16 @@ describe('AuthService', () => {
 
       expect(mockedUserService.createUser).toBeCalledWith(ctx, registerInput);
       expect(result).toEqual(userOutput);
+    });
+
+    it('should throw bad request exception for existing username', async () => {
+      jest
+        .spyOn(mockedUserService, 'findByUsername')
+        .mockImplementation(() => true);
+
+      await expect(service.register(ctx, registerInput)).rejects.toThrowError(
+        BadRequestException,
+      );
     });
   });
 

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -66,10 +66,10 @@ export class AuthService {
 
     // check for existing records
     if (await this.userService.findByUsername(ctx, input.username)) {
-      throw new BadRequestException('The username has already been taken.');
+      throw new BadRequestException(['The username has already been taken.']);
     }
     if (await this.userService.findByEmail(ctx, input.email)) {
-      throw new BadRequestException('The email has already been taken.');
+      throw new BadRequestException(['The email has already been taken.']);
     }
 
     // TODO : Setting default role as USER here. Will add option to change this later via ADMIN users.

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -65,11 +65,14 @@ export class AuthService {
     this.logger.log(ctx, `${this.register.name} was called`);
 
     // check for existing records
-    if (await this.userService.findByUsername(ctx, input.username)) {
-      throw new BadRequestException(['The username has already been taken.']);
-    }
-    if (await this.userService.findByEmail(ctx, input.email)) {
-      throw new BadRequestException(['The email has already been taken.']);
+    if (
+      await this.userService.findByUsernameOrEmail(
+        ctx,
+        input.username,
+        input.email,
+      )
+    ) {
+      throw new BadRequestException(['User already exists.']);
     }
 
     // TODO : Setting default role as USER here. Will add option to change this later via ADMIN users.

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { plainToClass } from 'class-transformer';
@@ -59,6 +63,14 @@ export class AuthService {
     input: RegisterInput,
   ): Promise<RegisterOutput> {
     this.logger.log(ctx, `${this.register.name} was called`);
+
+    // check for existing records
+    if (await this.userService.findByUsername(ctx, input.username)) {
+      throw new BadRequestException('The username has already been taken.');
+    }
+    if (await this.userService.findByEmail(ctx, input.email)) {
+      throw new BadRequestException('The email has already been taken.');
+    }
 
     // TODO : Setting default role as USER here. Will add option to change this later via ADMIN users.
     input.roles = [ROLE.USER];

--- a/src/shared/acl/actor.constant.ts
+++ b/src/shared/acl/actor.constant.ts
@@ -1,5 +1,3 @@
-import { ROLE } from './../../auth/constants/role.constant';
-
 /**
  * The actor who is perfoming the action
  */

--- a/src/shared/filters/all-exceptions.filter.spec.ts
+++ b/src/shared/filters/all-exceptions.filter.spec.ts
@@ -21,7 +21,7 @@ describe('AllExceptionsFilter', () => {
   let mockResponse: any;
 
   const mockConfigService = {
-    get: (key) => 'development',
+    get: () => 'development',
   };
   const mockedLogger = {
     warn: jest.fn().mockReturnThis(),
@@ -180,7 +180,7 @@ describe('AllExceptionsFilter', () => {
 
     const dateSpy = jest
       .spyOn(global, 'Date')
-      .mockImplementation(() => (mockDate as unknown) as string);
+      .mockImplementation(() => mockDate as unknown as string);
 
     filter.catch(mockException1, mockContext);
     expect(mockResponse.status).toBeCalledWith(HttpStatus.NOT_FOUND);

--- a/src/user/services/user.service.spec.ts
+++ b/src/user/services/user.service.spec.ts
@@ -285,22 +285,26 @@ describe('UserService', () => {
     });
   });
 
-  describe('findByEmail', () => {
+  describe('findByUsernameOrEmail', () => {
     beforeEach(() => {
       jest
         .spyOn(mockedRepository, 'findOne')
         .mockImplementation(async () => user);
     });
 
-    it('should find user from DB using given email', async () => {
-      await service.findByEmail(ctx, user.email);
+    it('should find user from DB using given username and email', async () => {
+      await service.findByUsernameOrEmail(ctx, user.username, user.email);
       expect(mockedRepository.findOne).toBeCalledWith({
-        email: user.email,
+        where: [{ username: user.username }, { email: user.email }],
       });
     });
 
     it('should return serialized user', async () => {
-      const result = await service.findByEmail(ctx, user.email);
+      const result = await service.findByUsernameOrEmail(
+        ctx,
+        user.username,
+        user.email,
+      );
 
       expect(result).toEqual({
         id: user.id,

--- a/src/user/services/user.service.spec.ts
+++ b/src/user/services/user.service.spec.ts
@@ -24,6 +24,7 @@ describe('UserService', () => {
     id: 6,
     username: 'jhon',
     name: 'Jhon doe',
+    email: 'randomUser@random.com',
     roles: [ROLE.USER],
   };
 
@@ -68,7 +69,7 @@ describe('UserService', () => {
         password: 'plain-password',
         roles: [ROLE.USER],
         isAccountDisabled: false,
-        email: 'randomUser@random.com',
+        email: user.email,
       };
 
       await service.createUser(ctx, userInput);
@@ -82,7 +83,7 @@ describe('UserService', () => {
         password: 'plain-password',
         roles: [ROLE.USER],
         isAccountDisabled: false,
-        email: 'randomUser@random.com',
+        email: user.email,
       };
 
       await service.createUser(ctx, userInput);
@@ -93,7 +94,7 @@ describe('UserService', () => {
         password: 'hashed-password',
         roles: [ROLE.USER],
         isAccountDisabled: false,
-        email: 'randomUser@random.com',
+        email: user.email,
       });
     });
 
@@ -109,7 +110,7 @@ describe('UserService', () => {
         password: 'plain-password',
         roles: [ROLE.USER],
         isAccountDisabled: false,
-        email: 'randomUser@random.com',
+        email: user.email,
       };
 
       const result = await service.createUser(ctx, userInput);
@@ -120,7 +121,7 @@ describe('UserService', () => {
         username: userInput.username,
         roles: [ROLE.USER],
         isAccountDisabled: false,
-        email: 'randomUser@random.com',
+        email: userInput.email,
       });
       expect(result).not.toHaveProperty('password');
     });
@@ -149,6 +150,7 @@ describe('UserService', () => {
         id: user.id,
         name: user.name,
         username: user.username,
+        email: user.email,
         roles: [ROLE.USER],
       });
     });
@@ -177,6 +179,7 @@ describe('UserService', () => {
         id: user.id,
         name: user.name,
         username: user.username,
+        email: user.email,
         roles: [ROLE.USER],
       });
     });
@@ -235,6 +238,7 @@ describe('UserService', () => {
         id: user.id,
         name: user.name,
         username: user.username,
+        email: user.email,
         roles: [ROLE.USER],
       });
     });
@@ -271,6 +275,38 @@ describe('UserService', () => {
         id: user.id,
         name: user.name,
         username: user.username,
+        email: user.email,
+        roles: [ROLE.USER],
+      });
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+  });
+
+  describe('findByEmail', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(mockedRepository, 'findOne')
+        .mockImplementation(async () => user);
+    });
+
+    it('should find user from DB using given email', async () => {
+      await service.findByEmail(ctx, user.email);
+      expect(mockedRepository.findOne).toBeCalledWith({
+        email: user.email,
+      });
+    });
+
+    it('should return serialized user', async () => {
+      const result = await service.findByEmail(ctx, user.email);
+
+      expect(result).toEqual({
+        id: user.id,
+        name: user.name,
+        username: user.username,
+        email: user.email,
         roles: [ROLE.USER],
       });
     });

--- a/src/user/services/user.service.ts
+++ b/src/user/services/user.service.ts
@@ -112,11 +112,17 @@ export class UserService {
     });
   }
 
-  async findByEmail(ctx: RequestContext, email: string): Promise<UserOutput> {
-    this.logger.log(ctx, `${this.findByEmail.name} was called`);
+  async findByUsernameOrEmail(
+    ctx: RequestContext,
+    username: string,
+    email: string,
+  ): Promise<UserOutput> {
+    this.logger.log(ctx, `${this.findByUsernameOrEmail.name} was called`);
 
     this.logger.log(ctx, `calling ${UserRepository.name}.findOne`);
-    const user = await this.repository.findOne({ email });
+    const user = await this.repository.findOne({
+      where: [{ username }, { email }],
+    });
 
     return plainToClass(UserOutput, user, {
       excludeExtraneousValues: true,

--- a/src/user/services/user.service.ts
+++ b/src/user/services/user.service.ts
@@ -112,6 +112,17 @@ export class UserService {
     });
   }
 
+  async findByEmail(ctx: RequestContext, email: string): Promise<UserOutput> {
+    this.logger.log(ctx, `${this.findByEmail.name} was called`);
+
+    this.logger.log(ctx, `calling ${UserRepository.name}.findOne`);
+    const user = await this.repository.findOne({ email });
+
+    return plainToClass(UserOutput, user, {
+      excludeExtraneousValues: true,
+    });
+  }
+
   async updateUser(
     ctx: RequestContext,
     userId: number,


### PR DESCRIPTION
Close #263.

It now throws:
```js
{
    "error": {
        "statusCode": 400,
        "message": "Bad Request Exception",
        "errorName": "BadRequestException",
        "details": {
            "statusCode": 400,
            "message": [
                "User already exists."
            ],
            "error": "Bad Request"
        },
        "path": "/api/v1/auth/register",
        "requestId": "aebd2215-b057-4795-be96-eb5f16a39c32",
        "timestamp": "2022-06-27T12:29:12.488Z"
    }
}
```