### PR TITLE
chore(tests): fix docker compose for GH action

### DIFF
--- a/.github/workflows/tests-workflow.yml
+++ b/.github/workflows/tests-workflow.yml
@@ -39,8 +39,8 @@ jobs:
       - run: npm ci
       - name: Run unit tests
         run: npm test
-      - name: Build the docker-compose stack
-        run: docker-compose -f docker-compose.yml up -d pgsqldb
+      - name: Build the docker compose stack
+        run: docker compose -f docker-compose.yml up -d pgsqldb
       - name: Check running containers
         run: docker ps -a
       - name: Run e2e tests


### PR DESCRIPTION
# Description

GitHub Actions Ubuntu runners now include Docker Compose v2, which is a Docker CLI plugin and is invoked as:
```
docker compose
```

This needs to merged so that tests can run successfully on Github Actions.